### PR TITLE
Mv emb timestamps screens here

### DIFF
--- a/tsFifoScreens/emb-timestamps.edl
+++ b/tsFifoScreens/emb-timestamps.edl
@@ -1,0 +1,943 @@
+4 0 1
+beginScreenProperties
+major 4
+minor 0
+release 1
+x 1977
+y 1127
+w 382
+h 168
+font "helvetica-medium-r-12.0"
+ctlFont "helvetica-medium-r-12.0"
+btnFont "helvetica-medium-r-12.0"
+fgColor index 14
+bgColor index 3
+textColor index 14
+ctlFgColor1 index 15
+ctlFgColor2 index 25
+ctlBgColor1 index 12
+ctlBgColor2 index 5
+topShadowColor index 1
+botShadowColor index 11
+title "emb-timestamps"
+showGrid
+snapToGrid
+gridSize 4
+endScreenProperties
+
+# (Group)
+object activeGroupClass
+beginObjectProperties
+major 4
+minor 0
+release 0
+x 204
+y 12
+w 172
+h 20
+
+beginGroup
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 296
+y 12
+w 80
+h 20
+font "helvetica-bold-r-14.0"
+fgColor index 20
+bgColor index 0
+useDisplayBg
+value {
+  "Not Owned"
+}
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 204
+y 12
+w 88
+h 20
+font "helvetica-medium-r-12.0"
+fontAlign "right"
+fgColor index 14
+bgColor index 0
+useDisplayBg
+value {
+  "EVR Trig $(CH)"
+}
+endObjectProperties
+
+endGroup
+
+visPv "$(EVR):CTRL.IP$(CH)E"
+visMin "0"
+visMax "1"
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 4
+y 12
+w 120
+h 20
+font "helvetica-medium-r-12.0"
+fontAlign "right"
+fgColor index 14
+bgColor index 0
+useDisplayBg
+value {
+  "Trig Event Code"
+}
+endObjectProperties
+
+# (Text Control)
+object activeXTextDspClass
+beginObjectProperties
+major 4
+minor 7
+release 0
+x 132
+y 12
+w 64
+h 20
+controlPv "$(P)$(R)CamEventCode"
+format "decimal"
+font "helvetica-medium-r-12.0"
+fontAlign "center"
+fgColor index 25
+fgAlarm
+bgColor index 5
+editable
+motifWidget
+limitsFromDb
+nullColor index 40
+smartRefresh
+fastUpdate
+useHexPrefix
+newPos
+objType "controls"
+noExecuteClipMask
+endObjectProperties
+
+# (Group)
+object activeGroupClass
+beginObjectProperties
+major 4
+minor 0
+release 0
+x 216
+y 12
+w 144
+h 20
+
+beginGroup
+
+# (Text Monitor)
+object activeXTextDspClass:noedit
+beginObjectProperties
+major 4
+minor 7
+release 0
+x 288
+y 12
+w 72
+h 20
+controlPv "$(P)$(R)CamRepRate_RBV"
+font "helvetica-medium-r-12.0"
+fontAlign "center"
+fgColor index 15
+fgAlarm
+bgColor index 12
+limitsFromDb
+nullColor index 40
+smartRefresh
+useHexPrefix
+showUnits
+newPos
+objType "monitors"
+noExecuteClipMask
+endObjectProperties
+
+# (Text Monitor)
+object activeXTextDspClass:noedit
+beginObjectProperties
+major 4
+minor 7
+release 0
+x 216
+y 12
+w 64
+h 20
+controlPv "$(P)$(R)TSS:EventCode_RBV"
+font "helvetica-medium-r-12.0"
+fontAlign "center"
+fgColor index 15
+fgAlarm
+bgColor index 12
+limitsFromDb
+nullColor index 40
+smartRefresh
+useHexPrefix
+showUnits
+newPos
+objType "monitors"
+noExecuteClipMask
+endObjectProperties
+
+endGroup
+
+visPv "$(EVR):CTRL.IP$(CH)E"
+visMin "1"
+visMax "2"
+endObjectProperties
+
+# (Group)
+object activeGroupClass
+beginObjectProperties
+major 4
+minor 0
+release 0
+x 8
+y 68
+w 336
+h 48
+
+beginGroup
+
+# (Text Monitor)
+object activeXTextDspClass:noedit
+beginObjectProperties
+major 4
+minor 7
+release 0
+x 272
+y 68
+w 92
+h 20
+controlPv "$(P)$(R)TSS:ExpectedDelay"
+format "gfloat"
+font "helvetica-medium-r-12.0"
+fontAlign "center"
+fgColor index 15
+fgAlarm
+bgColor index 12
+limitsFromDb
+nullColor index 40
+smartRefresh
+useHexPrefix
+showUnits
+newPos
+objType "monitors"
+noExecuteClipMask
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 8
+y 68
+w 64
+h 20
+font "helvetica-medium-r-12.0"
+fontAlign "right"
+fgColor index 14
+bgColor index 0
+useDisplayBg
+value {
+  "Xmit Delay"
+}
+endObjectProperties
+
+# (Text Monitor)
+object activeXTextDspClass:noedit
+beginObjectProperties
+major 4
+minor 7
+release 0
+x 76
+y 68
+w 84
+h 20
+controlPv "$(P)$(R)XmitDelay"
+format "gfloat"
+font "helvetica-medium-r-12.0"
+fontAlign "center"
+fgColor index 15
+fgAlarm
+bgColor index 12
+limitsFromDb
+nullColor index 40
+smartRefresh
+useHexPrefix
+showUnits
+newPos
+objType "monitors"
+noExecuteClipMask
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 168
+y 68
+w 96
+h 20
+font "helvetica-medium-r-12.0"
+fontAlign "right"
+fgColor index 14
+bgColor index 0
+useDisplayBg
+value {
+  "Total Exp Delay"
+}
+endObjectProperties
+
+# (Text Monitor)
+object activeXTextDspClass:noedit
+beginObjectProperties
+major 4
+minor 7
+release 0
+x 304
+y 96
+w 60
+h 20
+controlPv "$(P)$(R)TSS:DiffVsExpMax"
+format "gfloat"
+font "helvetica-medium-r-12.0"
+fontAlign "center"
+fgColor index 15
+fgAlarm
+bgColor index 12
+limitsFromDb
+nullColor index 40
+smartRefresh
+useHexPrefix
+showUnits
+newPos
+objType "monitors"
+noExecuteClipMask
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 272
+y 96
+w 28
+h 20
+font "helvetica-medium-r-12.0"
+fontAlign "right"
+fgColor index 14
+bgColor index 0
+useDisplayBg
+value {
+  "Max"
+}
+endObjectProperties
+
+# (Text Monitor)
+object activeXTextDspClass:noedit
+beginObjectProperties
+major 4
+minor 7
+release 0
+x 188
+y 96
+w 68
+h 20
+controlPv "$(P)$(R)TSS:DiffVsExpMin"
+format "gfloat"
+font "helvetica-medium-r-12.0"
+fontAlign "center"
+fgColor index 15
+fgAlarm
+bgColor index 12
+limitsFromDb
+nullColor index 40
+smartRefresh
+useHexPrefix
+showUnits
+newPos
+objType "monitors"
+noExecuteClipMask
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 152
+y 96
+w 24
+h 20
+font "helvetica-medium-r-12.0"
+fontAlign "right"
+fgColor index 14
+bgColor index 0
+useDisplayBg
+value {
+  "Min"
+}
+endObjectProperties
+
+# (Text Monitor)
+object activeXTextDspClass:noedit
+beginObjectProperties
+major 4
+minor 7
+release 0
+x 76
+y 96
+w 68
+h 20
+controlPv "$(P)$(R)TSS:DiffVsExp"
+format "gfloat"
+font "helvetica-medium-r-12.0"
+fontAlign "center"
+fgColor index 15
+fgAlarm
+bgColor index 12
+limitsFromDb
+nullColor index 40
+smartRefresh
+useHexPrefix
+showUnits
+newPos
+objType "monitors"
+noExecuteClipMask
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 8
+y 96
+w 60
+h 20
+font "helvetica-medium-r-12.0"
+fontAlign "right"
+fgColor index 14
+bgColor index 0
+useDisplayBg
+value {
+  "DiffVsExp"
+}
+endObjectProperties
+
+endGroup
+
+visPv "CALC\\\{A=0&&B=1\}($(P)$(R)TSS:TsFreeRun.RVAL,$(P)$(R)TSS:TsPolicy.RVAL)"
+visMin "1"
+visMax "2"
+endObjectProperties
+
+# (Group)
+object activeGroupClass
+beginObjectProperties
+major 4
+minor 0
+release 0
+x 8
+y 68
+w 356
+h 48
+
+beginGroup
+
+# (Text Monitor)
+object activeXTextDspClass:noedit
+beginObjectProperties
+major 4
+minor 7
+release 0
+x 312
+y 96
+w 52
+h 20
+controlPv "$(P)$(R)TSS:DiffVsIntAvg"
+format "gfloat"
+font "helvetica-medium-r-12.0"
+fontAlign "center"
+fgColor index 15
+fgAlarm
+bgColor index 12
+limitsFromDb
+nullColor index 40
+smartRefresh
+useHexPrefix
+newPos
+objType "monitors"
+noExecuteClipMask
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 286
+y 96
+w 22
+h 20
+font "helvetica-medium-r-12.0"
+fontAlign "right"
+fgColor index 14
+bgColor index 0
+useDisplayBg
+value {
+  "Avg"
+}
+endObjectProperties
+
+# (Message Button)
+object activeMessageButtonClass
+beginObjectProperties
+major 4
+minor 1
+release 0
+x 304
+y 68
+w 60
+h 20
+fgColor index 25
+onColor index 6
+offColor index 3
+topShadowColor index 1
+botShadowColor index 13
+controlPv "$(P)$(R)TSS:IntReq"
+pressValue "2"
+onLabel "Tweak +"
+offLabel "Tweak +"
+3d
+useEnumNumeric
+font "helvetica-medium-r-14.0"
+endObjectProperties
+
+# (Text Monitor)
+object activeXTextDspClass:noedit
+beginObjectProperties
+major 4
+minor 7
+release 0
+x 227
+y 96
+w 52
+h 20
+controlPv "$(P)$(R)TSS:DiffVsIntMax"
+format "gfloat"
+font "helvetica-medium-r-12.0"
+fontAlign "center"
+fgColor index 15
+fgAlarm
+bgColor index 12
+limitsFromDb
+nullColor index 40
+smartRefresh
+useHexPrefix
+newPos
+objType "monitors"
+noExecuteClipMask
+endObjectProperties
+
+# (Message Button)
+object activeMessageButtonClass
+beginObjectProperties
+major 4
+minor 1
+release 0
+x 228
+y 68
+w 60
+h 20
+fgColor index 25
+onColor index 6
+offColor index 3
+topShadowColor index 1
+botShadowColor index 13
+controlPv "$(P)$(R)TSS:IntReq"
+pressValue "1"
+onLabel "Set"
+offLabel "Set"
+3d
+useEnumNumeric
+font "helvetica-medium-r-14.0"
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 200
+y 96
+w 24
+h 20
+font "helvetica-medium-r-12.0"
+fontAlign "right"
+fgColor index 14
+bgColor index 0
+useDisplayBg
+value {
+  "Max"
+}
+endObjectProperties
+
+# (Text Monitor)
+object activeXTextDspClass:noedit
+beginObjectProperties
+major 4
+minor 7
+release 0
+x 142
+y 96
+w 52
+h 20
+controlPv "$(P)$(R)TSS:DiffVsIntMin"
+format "gfloat"
+font "helvetica-medium-r-12.0"
+fontAlign "center"
+fgColor index 15
+fgAlarm
+bgColor index 12
+limitsFromDb
+nullColor index 40
+smartRefresh
+useHexPrefix
+newPos
+objType "monitors"
+noExecuteClipMask
+endObjectProperties
+
+# (Message Button)
+object activeMessageButtonClass
+beginObjectProperties
+major 4
+minor 1
+release 0
+x 148
+y 68
+w 60
+h 20
+fgColor index 25
+onColor index 6
+offColor index 3
+topShadowColor index 1
+botShadowColor index 13
+controlPv "$(P)$(R)TSS:IntReq"
+pressValue "3"
+onLabel "Tweak -"
+offLabel "Tweak -"
+3d
+useEnumNumeric
+font "helvetica-medium-r-14.0"
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 118
+y 96
+w 22
+h 20
+font "helvetica-medium-r-12.0"
+fontAlign "right"
+fgColor index 14
+bgColor index 0
+useDisplayBg
+value {
+  "Min"
+}
+endObjectProperties
+
+# (Text Monitor)
+object activeXTextDspClass:noedit
+beginObjectProperties
+major 4
+minor 7
+release 0
+x 60
+y 96
+w 52
+h 20
+controlPv "$(P)$(R)TSS:DiffVsInt"
+format "gfloat"
+font "helvetica-medium-r-12.0"
+fontAlign "center"
+fgColor index 15
+fgAlarm
+bgColor index 12
+limitsFromDb
+nullColor index 40
+smartRefresh
+useHexPrefix
+newPos
+objType "monitors"
+noExecuteClipMask
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 8
+y 68
+w 40
+h 20
+font "helvetica-medium-r-12.0"
+fgColor index 14
+bgColor index 0
+useDisplayBg
+value {
+  "Status:"
+}
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 8
+y 96
+w 48
+h 20
+font "helvetica-medium-r-12.0"
+fontAlign "right"
+fgColor index 14
+bgColor index 0
+useDisplayBg
+value {
+  "Diff (ms)"
+}
+endObjectProperties
+
+endGroup
+
+visPv "CALC\\\{A=0&&B=3\}($(P)$(R)TSS:TsFreeRun.RVAL,$(P)$(R)TSS:TsPolicy.RVAL)"
+visMin "1"
+visMax "2"
+endObjectProperties
+
+# (Group)
+object activeGroupClass
+beginObjectProperties
+major 4
+minor 0
+release 0
+x 60
+y 68
+w 64
+h 20
+
+beginGroup
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 60
+y 68
+w 64
+h 20
+font "helvetica-bold-r-14.0"
+fgColor index 14
+bgColor index 0
+useDisplayBg
+value {
+  "Synced"
+}
+endObjectProperties
+
+endGroup
+
+visPv "CALC\\\{A=0&&B=3&C=1\}($(P)$(R)TSS:TsFreeRun.RVAL,$(P)$(R)TSS:TsPolicy.RVAL,$(P)$(R)TSS:INTERNAL_SYNC)"
+visMin "1"
+visMax "2"
+endObjectProperties
+
+# (Group)
+object activeGroupClass
+beginObjectProperties
+major 4
+minor 0
+release 0
+x 60
+y 68
+w 80
+h 20
+
+beginGroup
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 60
+y 68
+w 80
+h 20
+font "helvetica-bold-r-14.0"
+fgColor index 20
+bgColor index 0
+useDisplayBg
+value {
+  "Not Synced"
+}
+endObjectProperties
+
+endGroup
+
+visPv "CALC\\\{A=0&&B=3&C=0\}($(P)$(R)TSS:TsFreeRun.RVAL,$(P)$(R)TSS:TsPolicy.RVAL,$(P)$(R)TSS:INTERNAL_SYNC)"
+visMin "1"
+visMax "2"
+endObjectProperties
+
+# (Text Monitor)
+object activeXTextDspClass:noedit
+beginObjectProperties
+major 4
+minor 7
+release 0
+x 272
+y 40
+w 92
+h 20
+controlPv "$(P)$(R)TSS:SyncStatus"
+format "gfloat"
+font "helvetica-medium-r-12.0"
+fontAlign "center"
+fgColor index 15
+fgAlarm
+bgColor index 12
+limitsFromDb
+nullColor index 40
+smartRefresh
+useHexPrefix
+newPos
+objType "monitors"
+noExecuteClipMask
+endObjectProperties
+
+# (Menu Button)
+object activeMenuButtonClass
+beginObjectProperties
+major 4
+minor 0
+release 0
+x 164
+y 40
+w 100
+h 20
+fgColor index 25
+bgColor index 5
+inconsistentColor index 40
+topShadowColor index 2
+botShadowColor index 13
+controlPv "$(P)$(R)TSS:TsPolicy"
+indicatorPv "$(P)$(R)TSS:TsPolicy"
+font "helvetica-medium-r-14.0"
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 8
+y 40
+w 120
+h 20
+font "helvetica-medium-r-12.0"
+fontAlign "right"
+fgColor index 14
+bgColor index 0
+useDisplayBg
+value {
+  "Sync Policy/Status"
+}
+endObjectProperties
+
+# (Group)
+object activeGroupClass
+beginObjectProperties
+major 4
+minor 0
+release 0
+x 148
+y 128
+w 60
+h 20
+
+beginGroup
+
+# (Shell Command)
+object shellCmdClass
+beginObjectProperties
+major 4
+minor 3
+release 0
+x 148
+y 128
+w 60
+h 20
+fgColor index 25
+bgColor index 3
+topShadowColor index 1
+botShadowColor index 13
+font "helvetica-medium-r-14.0"
+buttonLabel "SyncTS"
+numCmds 1
+command {
+  0 "$\{SYNCTS\}"
+}
+endObjectProperties
+
+endGroup
+
+visPv "CALC\\\{A=0&&B=3\}($(P)$(R)TSS:TsFreeRun.RVAL,$(P)$(R)TSS:TsPolicy.RVAL)"
+visMin "1"
+visMax "2"
+endObjectProperties
+

--- a/tsFifoScreens/emb-timestamps.edl
+++ b/tsFifoScreens/emb-timestamps.edl
@@ -182,7 +182,7 @@ x 216
 y 12
 w 64
 h 20
-controlPv "$(P)$(R)TSS:EventCode_RBV"
+controlPv "$(TSS):EventCode_RBV"
 font "helvetica-medium-r-12.0"
 fontAlign "center"
 fgColor index 15
@@ -228,7 +228,7 @@ x 272
 y 68
 w 92
 h 20
-controlPv "$(P)$(R)TSS:ExpectedDelay"
+controlPv "$(TSS):ExpectedDelay"
 format "gfloat"
 font "helvetica-medium-r-12.0"
 fontAlign "center"
@@ -322,7 +322,7 @@ x 304
 y 96
 w 60
 h 20
-controlPv "$(P)$(R)TSS:DiffVsExpMax"
+controlPv "$(TSS):DiffVsExpMax"
 format "gfloat"
 font "helvetica-medium-r-12.0"
 fontAlign "center"
@@ -369,7 +369,7 @@ x 188
 y 96
 w 68
 h 20
-controlPv "$(P)$(R)TSS:DiffVsExpMin"
+controlPv "$(TSS):DiffVsExpMin"
 format "gfloat"
 font "helvetica-medium-r-12.0"
 fontAlign "center"
@@ -416,7 +416,7 @@ x 76
 y 96
 w 68
 h 20
-controlPv "$(P)$(R)TSS:DiffVsExp"
+controlPv "$(TSS):DiffVsExp"
 format "gfloat"
 font "helvetica-medium-r-12.0"
 fontAlign "center"
@@ -455,7 +455,7 @@ endObjectProperties
 
 endGroup
 
-visPv "CALC\\\{A=0&&B=1\}($(P)$(R)TSS:TsFreeRun.RVAL,$(P)$(R)TSS:TsPolicy.RVAL)"
+visPv "CALC\\\{A=0&&B=1\}($(TSS):TsFreeRun.RVAL,$(TSS):TsPolicy.RVAL)"
 visMin "1"
 visMax "2"
 endObjectProperties
@@ -483,7 +483,7 @@ x 312
 y 96
 w 52
 h 20
-controlPv "$(P)$(R)TSS:DiffVsIntAvg"
+controlPv "$(TSS):DiffVsIntAvg"
 format "gfloat"
 font "helvetica-medium-r-12.0"
 fontAlign "center"
@@ -534,7 +534,7 @@ onColor index 6
 offColor index 3
 topShadowColor index 1
 botShadowColor index 13
-controlPv "$(P)$(R)TSS:IntReq"
+controlPv "$(TSS):IntReq"
 pressValue "2"
 onLabel "Tweak +"
 offLabel "Tweak +"
@@ -553,7 +553,7 @@ x 227
 y 96
 w 52
 h 20
-controlPv "$(P)$(R)TSS:DiffVsIntMax"
+controlPv "$(TSS):DiffVsIntMax"
 format "gfloat"
 font "helvetica-medium-r-12.0"
 fontAlign "center"
@@ -584,7 +584,7 @@ onColor index 6
 offColor index 3
 topShadowColor index 1
 botShadowColor index 13
-controlPv "$(P)$(R)TSS:IntReq"
+controlPv "$(TSS):IntReq"
 pressValue "1"
 onLabel "Set"
 offLabel "Set"
@@ -623,7 +623,7 @@ x 142
 y 96
 w 52
 h 20
-controlPv "$(P)$(R)TSS:DiffVsIntMin"
+controlPv "$(TSS):DiffVsIntMin"
 format "gfloat"
 font "helvetica-medium-r-12.0"
 fontAlign "center"
@@ -654,7 +654,7 @@ onColor index 6
 offColor index 3
 topShadowColor index 1
 botShadowColor index 13
-controlPv "$(P)$(R)TSS:IntReq"
+controlPv "$(TSS):IntReq"
 pressValue "3"
 onLabel "Tweak -"
 offLabel "Tweak -"
@@ -693,7 +693,7 @@ x 60
 y 96
 w 52
 h 20
-controlPv "$(P)$(R)TSS:DiffVsInt"
+controlPv "$(TSS):DiffVsInt"
 format "gfloat"
 font "helvetica-medium-r-12.0"
 fontAlign "center"
@@ -750,7 +750,7 @@ endObjectProperties
 
 endGroup
 
-visPv "CALC\\\{A=0&&B=3\}($(P)$(R)TSS:TsFreeRun.RVAL,$(P)$(R)TSS:TsPolicy.RVAL)"
+visPv "CALC\\\{A=0&&B=3\}($(TSS):TsFreeRun.RVAL,$(TSS):TsPolicy.RVAL)"
 visMin "1"
 visMax "2"
 endObjectProperties
@@ -789,7 +789,7 @@ endObjectProperties
 
 endGroup
 
-visPv "CALC\\\{A=0&&B=3&C=1\}($(P)$(R)TSS:TsFreeRun.RVAL,$(P)$(R)TSS:TsPolicy.RVAL,$(P)$(R)TSS:INTERNAL_SYNC)"
+visPv "CALC\\\{A=0&&B=3&C=1\}($(TSS):TsFreeRun.RVAL,$(TSS):TsPolicy.RVAL,$(TSS):INTERNAL_SYNC)"
 visMin "1"
 visMax "2"
 endObjectProperties
@@ -828,7 +828,7 @@ endObjectProperties
 
 endGroup
 
-visPv "CALC\\\{A=0&&B=3&C=0\}($(P)$(R)TSS:TsFreeRun.RVAL,$(P)$(R)TSS:TsPolicy.RVAL,$(P)$(R)TSS:INTERNAL_SYNC)"
+visPv "CALC\\\{A=0&&B=3&C=0\}($(TSS):TsFreeRun.RVAL,$(TSS):TsPolicy.RVAL,$(TSS):INTERNAL_SYNC)"
 visMin "1"
 visMax "2"
 endObjectProperties
@@ -843,7 +843,7 @@ x 272
 y 40
 w 92
 h 20
-controlPv "$(P)$(R)TSS:SyncStatus"
+controlPv "$(TSS):SyncStatus"
 format "gfloat"
 font "helvetica-medium-r-12.0"
 fontAlign "center"
@@ -874,8 +874,8 @@ bgColor index 5
 inconsistentColor index 40
 topShadowColor index 2
 botShadowColor index 13
-controlPv "$(P)$(R)TSS:TsPolicy"
-indicatorPv "$(P)$(R)TSS:TsPolicy"
+controlPv "$(TSS):TsPolicy"
+indicatorPv "$(TSS):TsPolicy"
 font "helvetica-medium-r-14.0"
 endObjectProperties
 
@@ -936,7 +936,7 @@ endObjectProperties
 
 endGroup
 
-visPv "CALC\\\{A=0&&B=3\}($(P)$(R)TSS:TsFreeRun.RVAL,$(P)$(R)TSS:TsPolicy.RVAL)"
+visPv "CALC\\\{A=0&&B=3\}($(TSS):TsFreeRun.RVAL,$(TSS):TsPolicy.RVAL)"
 visMin "1"
 visMax "2"
 endObjectProperties

--- a/tsFifoScreens/emb-tpr-timestamps.edl
+++ b/tsFifoScreens/emb-tpr-timestamps.edl
@@ -189,7 +189,7 @@ x 240
 y 8
 w 60
 h 20
-controlPv "$(P)$(R)TSS:EventCode_RBV"
+controlPv "$(TSS):EventCode_RBV"
 font "helvetica-medium-r-12.0"
 fontAlign "center"
 fgColor index 15
@@ -430,7 +430,7 @@ x 268
 y 66
 w 92
 h 20
-controlPv "$(P)$(R)TSS:ExpectedDelay"
+controlPv "$(TSS):ExpectedDelay"
 format "gfloat"
 font "helvetica-medium-r-12.0"
 fontAlign "center"
@@ -524,7 +524,7 @@ x 300
 y 94
 w 60
 h 20
-controlPv "$(P)$(R)TSS:DiffVsExpMax"
+controlPv "$(TSS):DiffVsExpMax"
 format "gfloat"
 font "helvetica-medium-r-12.0"
 fontAlign "center"
@@ -571,7 +571,7 @@ x 184
 y 94
 w 68
 h 20
-controlPv "$(P)$(R)TSS:DiffVsExpMin"
+controlPv "$(TSS):DiffVsExpMin"
 format "gfloat"
 font "helvetica-medium-r-12.0"
 fontAlign "center"
@@ -618,7 +618,7 @@ x 72
 y 94
 w 68
 h 20
-controlPv "$(P)$(R)TSS:DiffVsExp"
+controlPv "$(TSS):DiffVsExp"
 format "gfloat"
 font "helvetica-medium-r-12.0"
 fontAlign "center"
@@ -657,7 +657,7 @@ endObjectProperties
 
 endGroup
 
-visPv "CALC\\\{A=0&&B=1\}($(P)$(R)TSS:TsFreeRun.RVAL,$(P)$(R)TSS:TsPolicy.RVAL)"
+visPv "CALC\\\{A=0&&B=1\}($(TSS):TsFreeRun.RVAL,$(TSS):TsPolicy.RVAL)"
 visMin "1"
 visMax "2"
 endObjectProperties
@@ -685,7 +685,7 @@ x 308
 y 94
 w 52
 h 20
-controlPv "$(P)$(R)TSS:DiffVsIntAvg"
+controlPv "$(TSS):DiffVsIntAvg"
 format "gfloat"
 font "helvetica-medium-r-12.0"
 fontAlign "center"
@@ -736,7 +736,7 @@ onColor index 6
 offColor index 3
 topShadowColor index 1
 botShadowColor index 13
-controlPv "$(P)$(R)TSS:IntReq"
+controlPv "$(TSS):IntReq"
 pressValue "2"
 onLabel "Tweak +"
 offLabel "Tweak +"
@@ -755,7 +755,7 @@ x 223
 y 94
 w 52
 h 20
-controlPv "$(P)$(R)TSS:DiffVsIntMax"
+controlPv "$(TSS):DiffVsIntMax"
 format "gfloat"
 font "helvetica-medium-r-12.0"
 fontAlign "center"
@@ -786,7 +786,7 @@ onColor index 6
 offColor index 3
 topShadowColor index 1
 botShadowColor index 13
-controlPv "$(P)$(R)TSS:IntReq"
+controlPv "$(TSS):IntReq"
 pressValue "1"
 onLabel "Set"
 offLabel "Set"
@@ -825,7 +825,7 @@ x 138
 y 94
 w 52
 h 20
-controlPv "$(P)$(R)TSS:DiffVsIntMin"
+controlPv "$(TSS):DiffVsIntMin"
 format "gfloat"
 font "helvetica-medium-r-12.0"
 fontAlign "center"
@@ -856,7 +856,7 @@ onColor index 6
 offColor index 3
 topShadowColor index 1
 botShadowColor index 13
-controlPv "$(P)$(R)TSS:IntReq"
+controlPv "$(TSS):IntReq"
 pressValue "3"
 onLabel "Tweak -"
 offLabel "Tweak -"
@@ -895,7 +895,7 @@ x 56
 y 94
 w 52
 h 20
-controlPv "$(P)$(R)TSS:DiffVsInt"
+controlPv "$(TSS):DiffVsInt"
 format "gfloat"
 font "helvetica-medium-r-12.0"
 fontAlign "center"
@@ -952,7 +952,7 @@ endObjectProperties
 
 endGroup
 
-visPv "CALC\\\{A=0&&B=3\}($(P)$(R)TSS:TsFreeRun.RVAL,$(P)$(R)TSS:TsPolicy.RVAL)"
+visPv "CALC\\\{A=0&&B=3\}($(TSS):TsFreeRun.RVAL,$(TSS):TsPolicy.RVAL)"
 visMin "1"
 visMax "2"
 endObjectProperties
@@ -991,7 +991,7 @@ endObjectProperties
 
 endGroup
 
-visPv "CALC\\\{A=0&&B=3&C=1\}($(P)$(R)TSS:TsFreeRun.RVAL,$(P)$(R)TSS:TsPolicy.RVAL,$(P)$(R)TSS:INTERNAL_SYNC)"
+visPv "CALC\\\{A=0&&B=3&C=1\}($(TSS):TsFreeRun.RVAL,$(TSS):TsPolicy.RVAL,$(TSS):INTERNAL_SYNC)"
 visMin "1"
 visMax "2"
 endObjectProperties
@@ -1030,7 +1030,7 @@ endObjectProperties
 
 endGroup
 
-visPv "CALC\\\{A=0&&B=3&C=0\}($(P)$(R)TSS:TsFreeRun.RVAL,$(P)$(R)TSS:TsPolicy.RVAL,$(P)$(R)TSS:INTERNAL_SYNC)"
+visPv "CALC\\\{A=0&&B=3&C=0\}($(TSS):TsFreeRun.RVAL,$(TSS):TsPolicy.RVAL,$(TSS):INTERNAL_SYNC)"
 visMin "1"
 visMax "2"
 endObjectProperties
@@ -1045,7 +1045,7 @@ x 268
 y 38
 w 92
 h 20
-controlPv "$(P)$(R)TSS:SyncStatus"
+controlPv "$(TSS):SyncStatus"
 format "gfloat"
 font "helvetica-medium-r-12.0"
 fontAlign "center"
@@ -1076,8 +1076,8 @@ bgColor index 5
 inconsistentColor index 40
 topShadowColor index 2
 botShadowColor index 13
-controlPv "$(P)$(R)TSS:TsPolicy"
-indicatorPv "$(P)$(R)TSS:TsPolicy"
+controlPv "$(TSS):TsPolicy"
+indicatorPv "$(TSS):TsPolicy"
 font "helvetica-medium-r-14.0"
 endObjectProperties
 
@@ -1138,7 +1138,7 @@ endObjectProperties
 
 endGroup
 
-visPv "CALC\\\{A=0&&B=3\}($(P)$(R)TSS:TsFreeRun.RVAL,$(P)$(R)TSS:TsPolicy.RVAL)"
+visPv "CALC\\\{A=0&&B=3\}($(TSS):TsFreeRun.RVAL,$(TSS):TsPolicy.RVAL)"
 visMin "1"
 visMax "2"
 endObjectProperties

--- a/tsFifoScreens/emb-tpr-timestamps.edl
+++ b/tsFifoScreens/emb-tpr-timestamps.edl
@@ -1,0 +1,1145 @@
+4 0 1
+beginScreenProperties
+major 4
+minor 0
+release 1
+x 2171
+y 1435
+w 382
+h 261
+font "helvetica-medium-r-12.0"
+ctlFont "helvetica-medium-r-12.0"
+btnFont "helvetica-medium-r-12.0"
+fgColor index 14
+bgColor index 3
+textColor index 14
+ctlFgColor1 index 15
+ctlFgColor2 index 25
+ctlBgColor1 index 12
+ctlBgColor2 index 5
+topShadowColor index 1
+botShadowColor index 11
+title "emb-tpr-timestamps"
+showGrid
+snapToGrid
+gridSize 4
+endScreenProperties
+
+# (Group)
+object activeGroupClass
+beginObjectProperties
+major 4
+minor 0
+release 0
+x 68
+y 8
+w 80
+h 24
+
+beginGroup
+
+# (Text Control)
+object activeXTextDspClass
+beginObjectProperties
+major 4
+minor 7
+release 0
+x 68
+y 8
+w 80
+h 24
+controlPv "$(TPR_PV):CH$(TPR_CH)_SEQCODE"
+format "decimal"
+font "helvetica-medium-r-12.0"
+fgColor index 25
+bgColor index 5
+editable
+motifWidget
+limitsFromDb
+precision 0
+nullColor index 0
+updatePvOnDrop
+newPos
+objType "controls"
+endObjectProperties
+
+endGroup
+
+visPv "CALC\\\{(A=1)&&(B=1)&&(C=2)\}($(TPR_PV):MODE,$(TPR_PV):XPM_MODE,$(TPR_PV):CH$(TPR_CH)_RATEMODE)"
+visMin "1"
+visMax "2"
+endObjectProperties
+
+# (Group)
+object activeGroupClass
+beginObjectProperties
+major 4
+minor 0
+release 0
+x 68
+y 8
+w 80
+h 24
+
+beginGroup
+
+# (Text Control)
+object activeXTextDspClass
+beginObjectProperties
+major 4
+minor 7
+release 0
+x 68
+y 8
+w 80
+h 24
+controlPv "$(TPR_PV):CH$(TPR_CH)_PARTITION"
+format "decimal"
+font "helvetica-medium-r-12.0"
+fgColor index 25
+bgColor index 5
+editable
+motifWidget
+limitsFromDb
+precision 0
+nullColor index 0
+updatePvOnDrop
+newPos
+objType "controls"
+endObjectProperties
+
+endGroup
+
+visPv "CALC\\\{(A=1)&&(B=1)&&(C=3)\}($(TPR_PV):MODE,$(TPR_PV):XPM_MODE,$(TPR_PV):CH$(TPR_CH)_RATEMODE)"
+visMin "1"
+visMax "2"
+endObjectProperties
+
+# (Group)
+object activeGroupClass
+beginObjectProperties
+major 4
+minor 0
+release 0
+x 68
+y 8
+w 163
+h 24
+
+beginGroup
+
+# (Text Control)
+object activeXTextDspClass
+beginObjectProperties
+major 4
+minor 7
+release 0
+x 152
+y 8
+w 80
+h 24
+controlPv "$(TPR_PV):CH$(TPR_CH)_TSMASK"
+format "hex"
+font "helvetica-medium-r-12.0"
+fgColor index 25
+bgColor index 5
+editable
+motifWidget
+limitsFromDb
+precision 0
+nullColor index 0
+updatePvOnDrop
+newPos
+objType "controls"
+endObjectProperties
+
+# (Menu Button)
+object activeMenuButtonClass
+beginObjectProperties
+major 4
+minor 0
+release 0
+x 68
+y 8
+w 80
+h 24
+fgColor index 25
+bgColor index 5
+inconsistentColor index 14
+topShadowColor index 2
+botShadowColor index 13
+controlPv "$(TPR_PV):CH$(TPR_CH)_ACRATE"
+font "helvetica-medium-r-12.0"
+endObjectProperties
+
+endGroup
+
+visPv "CALC\\\{(A=1)&&(B=1)&&(C=1)\}($(TPR_PV):MODE,$(TPR_PV):XPM_MODE,$(TPR_PV):CH$(TPR_CH)_RATEMODE)"
+visMin "1"
+visMax "2"
+endObjectProperties
+
+# (Text Monitor)
+object activeXTextDspClass:noedit
+beginObjectProperties
+major 4
+minor 7
+release 0
+x 240
+y 8
+w 60
+h 20
+controlPv "$(P)$(R)TSS:EventCode_RBV"
+font "helvetica-medium-r-12.0"
+fontAlign "center"
+fgColor index 15
+fgAlarm
+bgColor index 12
+limitsFromDb
+nullColor index 40
+smartRefresh
+useHexPrefix
+showUnits
+newPos
+objType "monitors"
+noExecuteClipMask
+endObjectProperties
+
+# (Text Monitor)
+object activeXTextDspClass:noedit
+beginObjectProperties
+major 4
+minor 7
+release 0
+x 304
+y 8
+w 68
+h 20
+controlPv "$(TPR_PV):CH$(TPR_CH)_RATE"
+font "helvetica-medium-r-12.0"
+fontAlign "center"
+fgColor index 15
+fgAlarm
+bgColor index 12
+limitsFromDb
+nullColor index 40
+smartRefresh
+useHexPrefix
+showUnits
+newPos
+objType "monitors"
+noExecuteClipMask
+endObjectProperties
+
+# (Group)
+object activeGroupClass
+beginObjectProperties
+major 4
+minor 0
+release 0
+x 4
+y 8
+w 192
+h 24
+
+beginGroup
+
+# (Text Control)
+object activeXTextDspClass
+beginObjectProperties
+major 4
+minor 7
+release 0
+x 132
+y 8
+w 64
+h 24
+controlPv "$(TPR_PV):CH$(TPR_CH)_EVCODE"
+format "decimal"
+font "helvetica-medium-r-12.0"
+fontAlign "center"
+fgColor index 25
+fgAlarm
+bgColor index 5
+editable
+motifWidget
+limitsFromDb
+nullColor index 40
+smartRefresh
+fastUpdate
+useHexPrefix
+newPos
+objType "controls"
+noExecuteClipMask
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 4
+y 8
+w 120
+h 24
+font "helvetica-medium-r-12.0"
+fontAlign "right"
+fgColor index 14
+bgColor index 0
+useDisplayBg
+value {
+  "Trig Event Code"
+}
+endObjectProperties
+
+endGroup
+
+visPv "CALC\\\{A=0||B=0\}($(TPR_PV):MODE,$(TPR_PV):XPM_MODE)"
+visMin "1"
+visMax "2"
+endObjectProperties
+
+# (Group)
+object activeGroupClass
+beginObjectProperties
+major 4
+minor 0
+release 0
+x 68
+y 8
+w 80
+h 24
+
+beginGroup
+
+# (Menu Button)
+object activeMenuButtonClass
+beginObjectProperties
+major 4
+minor 0
+release 0
+x 68
+y 8
+w 80
+h 24
+fgColor index 25
+bgColor index 5
+inconsistentColor index 14
+topShadowColor index 2
+botShadowColor index 13
+controlPv "$(TPR_PV):CH$(TPR_CH)_FIXEDRATE"
+font "helvetica-medium-r-12.0"
+endObjectProperties
+
+endGroup
+
+visPv "CALC\\\{(A=1)&&(B=1)&&(C=0)\}($(TPR_PV):MODE,$(TPR_PV):XPM_MODE,$(TPR_PV):CH$(TPR_CH)_RATEMODE)"
+visMin "1"
+visMax "2"
+endObjectProperties
+
+# (Menu Button)
+object activeMenuButtonClass
+beginObjectProperties
+major 4
+minor 0
+release 0
+x 4
+y 8
+w 60
+h 24
+fgColor index 25
+bgColor index 5
+inconsistentColor index 14
+topShadowColor index 2
+botShadowColor index 13
+controlPv "$(TPR_PV):CH$(TPR_CH)_RATEMODE"
+font "helvetica-medium-r-12.0"
+visPv "CALC\\\{(A=1)&&(B=1)\}($(TPR_PV):MODE,$(TPR_PV):XPM_MODE)"
+visMin "1"
+visMax "2"
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 208
+y 124
+w 76
+h 20
+font "helvetica-medium-r-12.0"
+fontAlign "right"
+fgColor index 14
+bgColor index 0
+useDisplayBg
+value {
+  "Timing Mode"
+}
+endObjectProperties
+
+# (Text Monitor)
+object activeXTextDspClass:noedit
+beginObjectProperties
+major 4
+minor 7
+release 0
+x 292
+y 124
+w 68
+h 20
+controlPv "$(TPR_PV):MODE"
+format "gfloat"
+font "helvetica-medium-r-12.0"
+fontAlign "center"
+fgColor index 15
+fgAlarm
+bgColor index 12
+limitsFromDb
+nullColor index 40
+smartRefresh
+useHexPrefix
+newPos
+objType "monitors"
+noExecuteClipMask
+endObjectProperties
+
+# (Group)
+object activeGroupClass
+beginObjectProperties
+major 4
+minor 0
+release 0
+x 4
+y 66
+w 336
+h 48
+
+beginGroup
+
+# (Text Monitor)
+object activeXTextDspClass:noedit
+beginObjectProperties
+major 4
+minor 7
+release 0
+x 268
+y 66
+w 92
+h 20
+controlPv "$(P)$(R)TSS:ExpectedDelay"
+format "gfloat"
+font "helvetica-medium-r-12.0"
+fontAlign "center"
+fgColor index 15
+fgAlarm
+bgColor index 12
+limitsFromDb
+nullColor index 40
+smartRefresh
+useHexPrefix
+showUnits
+newPos
+objType "monitors"
+noExecuteClipMask
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 4
+y 66
+w 64
+h 20
+font "helvetica-medium-r-12.0"
+fontAlign "right"
+fgColor index 14
+bgColor index 0
+useDisplayBg
+value {
+  "Xmit Delay"
+}
+endObjectProperties
+
+# (Text Monitor)
+object activeXTextDspClass:noedit
+beginObjectProperties
+major 4
+minor 7
+release 0
+x 72
+y 66
+w 84
+h 20
+controlPv "$(P)$(R)XmitDelay"
+format "gfloat"
+font "helvetica-medium-r-12.0"
+fontAlign "center"
+fgColor index 15
+fgAlarm
+bgColor index 12
+limitsFromDb
+nullColor index 40
+smartRefresh
+useHexPrefix
+showUnits
+newPos
+objType "monitors"
+noExecuteClipMask
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 164
+y 66
+w 96
+h 20
+font "helvetica-medium-r-12.0"
+fontAlign "right"
+fgColor index 14
+bgColor index 0
+useDisplayBg
+value {
+  "Total Exp Delay"
+}
+endObjectProperties
+
+# (Text Monitor)
+object activeXTextDspClass:noedit
+beginObjectProperties
+major 4
+minor 7
+release 0
+x 300
+y 94
+w 60
+h 20
+controlPv "$(P)$(R)TSS:DiffVsExpMax"
+format "gfloat"
+font "helvetica-medium-r-12.0"
+fontAlign "center"
+fgColor index 15
+fgAlarm
+bgColor index 12
+limitsFromDb
+nullColor index 40
+smartRefresh
+useHexPrefix
+showUnits
+newPos
+objType "monitors"
+noExecuteClipMask
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 268
+y 94
+w 28
+h 20
+font "helvetica-medium-r-12.0"
+fontAlign "right"
+fgColor index 14
+bgColor index 0
+useDisplayBg
+value {
+  "Max"
+}
+endObjectProperties
+
+# (Text Monitor)
+object activeXTextDspClass:noedit
+beginObjectProperties
+major 4
+minor 7
+release 0
+x 184
+y 94
+w 68
+h 20
+controlPv "$(P)$(R)TSS:DiffVsExpMin"
+format "gfloat"
+font "helvetica-medium-r-12.0"
+fontAlign "center"
+fgColor index 15
+fgAlarm
+bgColor index 12
+limitsFromDb
+nullColor index 40
+smartRefresh
+useHexPrefix
+showUnits
+newPos
+objType "monitors"
+noExecuteClipMask
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 148
+y 94
+w 24
+h 20
+font "helvetica-medium-r-12.0"
+fontAlign "right"
+fgColor index 14
+bgColor index 0
+useDisplayBg
+value {
+  "Min"
+}
+endObjectProperties
+
+# (Text Monitor)
+object activeXTextDspClass:noedit
+beginObjectProperties
+major 4
+minor 7
+release 0
+x 72
+y 94
+w 68
+h 20
+controlPv "$(P)$(R)TSS:DiffVsExp"
+format "gfloat"
+font "helvetica-medium-r-12.0"
+fontAlign "center"
+fgColor index 15
+fgAlarm
+bgColor index 12
+limitsFromDb
+nullColor index 40
+smartRefresh
+useHexPrefix
+showUnits
+newPos
+objType "monitors"
+noExecuteClipMask
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 4
+y 94
+w 60
+h 20
+font "helvetica-medium-r-12.0"
+fontAlign "right"
+fgColor index 14
+bgColor index 0
+useDisplayBg
+value {
+  "DiffVsExp"
+}
+endObjectProperties
+
+endGroup
+
+visPv "CALC\\\{A=0&&B=1\}($(P)$(R)TSS:TsFreeRun.RVAL,$(P)$(R)TSS:TsPolicy.RVAL)"
+visMin "1"
+visMax "2"
+endObjectProperties
+
+# (Group)
+object activeGroupClass
+beginObjectProperties
+major 4
+minor 0
+release 0
+x 4
+y 66
+w 356
+h 48
+
+beginGroup
+
+# (Text Monitor)
+object activeXTextDspClass:noedit
+beginObjectProperties
+major 4
+minor 7
+release 0
+x 308
+y 94
+w 52
+h 20
+controlPv "$(P)$(R)TSS:DiffVsIntAvg"
+format "gfloat"
+font "helvetica-medium-r-12.0"
+fontAlign "center"
+fgColor index 15
+fgAlarm
+bgColor index 12
+limitsFromDb
+nullColor index 40
+smartRefresh
+useHexPrefix
+newPos
+objType "monitors"
+noExecuteClipMask
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 282
+y 94
+w 22
+h 20
+font "helvetica-medium-r-12.0"
+fontAlign "right"
+fgColor index 14
+bgColor index 0
+useDisplayBg
+value {
+  "Avg"
+}
+endObjectProperties
+
+# (Message Button)
+object activeMessageButtonClass
+beginObjectProperties
+major 4
+minor 1
+release 0
+x 300
+y 66
+w 60
+h 20
+fgColor index 25
+onColor index 6
+offColor index 3
+topShadowColor index 1
+botShadowColor index 13
+controlPv "$(P)$(R)TSS:IntReq"
+pressValue "2"
+onLabel "Tweak +"
+offLabel "Tweak +"
+3d
+useEnumNumeric
+font "helvetica-medium-r-14.0"
+endObjectProperties
+
+# (Text Monitor)
+object activeXTextDspClass:noedit
+beginObjectProperties
+major 4
+minor 7
+release 0
+x 223
+y 94
+w 52
+h 20
+controlPv "$(P)$(R)TSS:DiffVsIntMax"
+format "gfloat"
+font "helvetica-medium-r-12.0"
+fontAlign "center"
+fgColor index 15
+fgAlarm
+bgColor index 12
+limitsFromDb
+nullColor index 40
+smartRefresh
+useHexPrefix
+newPos
+objType "monitors"
+noExecuteClipMask
+endObjectProperties
+
+# (Message Button)
+object activeMessageButtonClass
+beginObjectProperties
+major 4
+minor 1
+release 0
+x 224
+y 66
+w 60
+h 20
+fgColor index 25
+onColor index 6
+offColor index 3
+topShadowColor index 1
+botShadowColor index 13
+controlPv "$(P)$(R)TSS:IntReq"
+pressValue "1"
+onLabel "Set"
+offLabel "Set"
+3d
+useEnumNumeric
+font "helvetica-medium-r-14.0"
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 196
+y 94
+w 24
+h 20
+font "helvetica-medium-r-12.0"
+fontAlign "right"
+fgColor index 14
+bgColor index 0
+useDisplayBg
+value {
+  "Max"
+}
+endObjectProperties
+
+# (Text Monitor)
+object activeXTextDspClass:noedit
+beginObjectProperties
+major 4
+minor 7
+release 0
+x 138
+y 94
+w 52
+h 20
+controlPv "$(P)$(R)TSS:DiffVsIntMin"
+format "gfloat"
+font "helvetica-medium-r-12.0"
+fontAlign "center"
+fgColor index 15
+fgAlarm
+bgColor index 12
+limitsFromDb
+nullColor index 40
+smartRefresh
+useHexPrefix
+newPos
+objType "monitors"
+noExecuteClipMask
+endObjectProperties
+
+# (Message Button)
+object activeMessageButtonClass
+beginObjectProperties
+major 4
+minor 1
+release 0
+x 144
+y 66
+w 60
+h 20
+fgColor index 25
+onColor index 6
+offColor index 3
+topShadowColor index 1
+botShadowColor index 13
+controlPv "$(P)$(R)TSS:IntReq"
+pressValue "3"
+onLabel "Tweak -"
+offLabel "Tweak -"
+3d
+useEnumNumeric
+font "helvetica-medium-r-14.0"
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 114
+y 94
+w 22
+h 20
+font "helvetica-medium-r-12.0"
+fontAlign "right"
+fgColor index 14
+bgColor index 0
+useDisplayBg
+value {
+  "Min"
+}
+endObjectProperties
+
+# (Text Monitor)
+object activeXTextDspClass:noedit
+beginObjectProperties
+major 4
+minor 7
+release 0
+x 56
+y 94
+w 52
+h 20
+controlPv "$(P)$(R)TSS:DiffVsInt"
+format "gfloat"
+font "helvetica-medium-r-12.0"
+fontAlign "center"
+fgColor index 15
+fgAlarm
+bgColor index 12
+limitsFromDb
+nullColor index 40
+smartRefresh
+useHexPrefix
+newPos
+objType "monitors"
+noExecuteClipMask
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 4
+y 66
+w 40
+h 20
+font "helvetica-medium-r-12.0"
+fgColor index 14
+bgColor index 0
+useDisplayBg
+value {
+  "Status:"
+}
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 4
+y 94
+w 48
+h 20
+font "helvetica-medium-r-12.0"
+fontAlign "right"
+fgColor index 14
+bgColor index 0
+useDisplayBg
+value {
+  "Diff (ms)"
+}
+endObjectProperties
+
+endGroup
+
+visPv "CALC\\\{A=0&&B=3\}($(P)$(R)TSS:TsFreeRun.RVAL,$(P)$(R)TSS:TsPolicy.RVAL)"
+visMin "1"
+visMax "2"
+endObjectProperties
+
+# (Group)
+object activeGroupClass
+beginObjectProperties
+major 4
+minor 0
+release 0
+x 54
+y 66
+w 64
+h 20
+
+beginGroup
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 54
+y 66
+w 64
+h 20
+font "helvetica-bold-r-14.0"
+fgColor index 14
+bgColor index 0
+useDisplayBg
+value {
+  "Synced"
+}
+endObjectProperties
+
+endGroup
+
+visPv "CALC\\\{A=0&&B=3&C=1\}($(P)$(R)TSS:TsFreeRun.RVAL,$(P)$(R)TSS:TsPolicy.RVAL,$(P)$(R)TSS:INTERNAL_SYNC)"
+visMin "1"
+visMax "2"
+endObjectProperties
+
+# (Group)
+object activeGroupClass
+beginObjectProperties
+major 4
+minor 0
+release 0
+x 54
+y 66
+w 80
+h 20
+
+beginGroup
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 54
+y 66
+w 80
+h 20
+font "helvetica-bold-r-14.0"
+fgColor index 20
+bgColor index 0
+useDisplayBg
+value {
+  "Not Synced"
+}
+endObjectProperties
+
+endGroup
+
+visPv "CALC\\\{A=0&&B=3&C=0\}($(P)$(R)TSS:TsFreeRun.RVAL,$(P)$(R)TSS:TsPolicy.RVAL,$(P)$(R)TSS:INTERNAL_SYNC)"
+visMin "1"
+visMax "2"
+endObjectProperties
+
+# (Text Monitor)
+object activeXTextDspClass:noedit
+beginObjectProperties
+major 4
+minor 7
+release 0
+x 268
+y 38
+w 92
+h 20
+controlPv "$(P)$(R)TSS:SyncStatus"
+format "gfloat"
+font "helvetica-medium-r-12.0"
+fontAlign "center"
+fgColor index 15
+fgAlarm
+bgColor index 12
+limitsFromDb
+nullColor index 40
+smartRefresh
+useHexPrefix
+newPos
+objType "monitors"
+noExecuteClipMask
+endObjectProperties
+
+# (Menu Button)
+object activeMenuButtonClass
+beginObjectProperties
+major 4
+minor 0
+release 0
+x 160
+y 38
+w 100
+h 20
+fgColor index 25
+bgColor index 5
+inconsistentColor index 40
+topShadowColor index 2
+botShadowColor index 13
+controlPv "$(P)$(R)TSS:TsPolicy"
+indicatorPv "$(P)$(R)TSS:TsPolicy"
+font "helvetica-medium-r-14.0"
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 4
+y 38
+w 120
+h 20
+font "helvetica-medium-r-12.0"
+fontAlign "right"
+fgColor index 14
+bgColor index 0
+useDisplayBg
+value {
+  "Sync Policy/Status"
+}
+endObjectProperties
+
+# (Group)
+object activeGroupClass
+beginObjectProperties
+major 4
+minor 0
+release 0
+x 145
+y 126
+w 60
+h 20
+
+beginGroup
+
+# (Shell Command)
+object shellCmdClass
+beginObjectProperties
+major 4
+minor 3
+release 0
+x 145
+y 126
+w 60
+h 20
+fgColor index 25
+bgColor index 3
+topShadowColor index 1
+botShadowColor index 13
+font "helvetica-medium-r-14.0"
+buttonLabel "SyncTS"
+numCmds 1
+command {
+  0 "$\{SYNCTS\}"
+}
+endObjectProperties
+
+endGroup
+
+visPv "CALC\\\{A=0&&B=3\}($(P)$(R)TSS:TsFreeRun.RVAL,$(P)$(R)TSS:TsPolicy.RVAL)"
+visMin "1"
+visMax "2"
+endObjectProperties
+


### PR DESCRIPTION
Moved the embedded timestamp screens emb-timestamps.edl and emb-tpr-timestamps.edl here from various IOCs.   We've been cloning copies of these screens in each IOC and the clones weren't in sync.   These files are the latest version and will work for all IOCs.