### PR TITLE
Fix for the mutex not being released with TOD ts policy

### DIFF
--- a/tsFifoLib/timeStampFifo.cpp
+++ b/tsFifoLib/timeStampFifo.cpp
@@ -565,6 +565,7 @@ int TSFifo::GetTimeStamp(
 		epicsTimeStamp		todTimeStamp;
 		evrTimeStatus	= epicsTimeGetCurrent( &todTimeStamp ); 
 		*pTimeStampRet	= todTimeStamp;
+		epicsMutexUnlock( m_TSLock );
 
 		if ( DEBUG_TS_FIFO >= 5 )
 		{


### PR DESCRIPTION
Fix for a bug where can exit from GetTimeStamp with out releasing the m_TSLock mutex in TOD mode. If you are always calling GetTimeStamp from the same thread you will miss this bug because the mutex is re-entrant (at least on linux). I checked and I don't see any other obvious return cases where the mutex is not released.

I discovered this because in ADVimba the GetTimeStamp gets called in callback function by the acquisition thread started by the sdk itself. In old version of the sdk this thread lived for the life of the program, so if using TOD ts policy you have no deadlock. The latest version of the vimba sdk it creates a new thread for every acquisition start, so the first time you started acquisition it would work but if you stopped then started again (new thread now) it would deadlock on the first call to GetTimeStamp.